### PR TITLE
Small documentation fixes to a curl command and content shuffler yaml config

### DIFF
--- a/2.7.x/get-started/beginner-tutorial.md
+++ b/2.7.x/get-started/beginner-tutorial.md
@@ -751,7 +751,7 @@ We have everything we need to make the comparison collage, but before we do that
 cat <<EOF > content_shuffler.yaml
 pipeline:
   name: content_shuffler
-  description: A pipeline that collapses our inputs into one datum for the collager.
+description: A pipeline that collapses our inputs into one datum for the collager.
 input:
   union:
     - pfs:

--- a/2.7.x/get-started/first-time-setup.md
+++ b/2.7.x/get-started/first-time-setup.md
@@ -112,7 +112,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo  tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo  tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{%/wizardResult%}}
  {{%/wizardResults%}}

--- a/2.7.x/set-up/local-deploy/docker.md
+++ b/2.7.x/set-up/local-deploy/docker.md
@@ -111,7 +111,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{%/wizardResult%}}
  {{%/wizardResults%}}

--- a/2.7.x/set-up/pachctl.md
+++ b/2.7.x/set-up/pachctl.md
@@ -39,7 +39,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{% /wizardResult%}}
  {{% /wizardResults%}}

--- a/latest/get-started/beginner-tutorial.md
+++ b/latest/get-started/beginner-tutorial.md
@@ -751,7 +751,7 @@ We have everything we need to make the comparison collage, but before we do that
 cat <<EOF > content_shuffler.yaml
 pipeline:
   name: content_shuffler
-  description: A pipeline that collapses our inputs into one datum for the collager.
+description: A pipeline that collapses our inputs into one datum for the collager.
 input:
   union:
     - pfs:

--- a/latest/get-started/first-time-setup.md
+++ b/latest/get-started/first-time-setup.md
@@ -112,7 +112,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo  tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo  tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{%/wizardResult%}}
  {{%/wizardResults%}}

--- a/latest/set-up/local-deploy/docker.md
+++ b/latest/set-up/local-deploy/docker.md
@@ -111,7 +111,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{%/wizardResult%}}
  {{%/wizardResults%}}

--- a/latest/set-up/pachctl.md
+++ b/latest/set-up/pachctl.md
@@ -39,7 +39,7 @@ curl -o /tmp/pachctl.deb -L https://github.com/pachyderm/pachyderm/releases/down
  ```
 **ARM**
 ```s
-curl-L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
+curl -L https://github.com/pachyderm/pachyderm/releases/download/v{{%latestPatchNumber%}}/pachctl_{{%latestPatchNumber%}}_linux_arm64.tar.gz | sudo tar -xzv --strip-components=1 -C /usr/local/bin
 ```
  {{% /wizardResult%}}
  {{% /wizardResults%}}


### PR DESCRIPTION
I was setting up my development environment and running through the beginner tutorials recently as part of onboarding. I noticed two small issues.

* `content_shuffler.yml` config had an indented `description:` property which does not match the expected schema. `description:` should be a top level property. 
* `curl-L` should be `curl -L`. Without the space between `curl` and `-L` the command is unrecognized.