### PR TITLE
[CORE-2096] Declare user metrics similarly to sidecar metrics

### DIFF
--- a/latest/manage/prometheus/podmonitor.yaml
+++ b/latest/manage/prometheus/podmonitor.yaml
@@ -3,11 +3,17 @@ kind: PodMonitor
 metadata:
   name: worker-scraper
   labels:
-    release: pach-prom
+    release: default
 spec:
   selector:
     matchLabels:
       app: pipeline
       component: worker
+  namespaceSelector:
+    matchNames:
+      - default
   podMetricsEndpoints:
   - port: metrics-storage
+    path: /metrics
+  - port: metrics-user
+    path: /metrics

--- a/latest/manage/prometheus/promservice.yaml
+++ b/latest/manage/prometheus/promservice.yaml
@@ -3,7 +3,7 @@ kind: ServiceMonitor
 metadata:
   name: pachyderm-scraper
   labels:
-    release: pach-prom
+    release: default
 spec:
     selector:
         matchLabels:


### PR DESCRIPTION
This corrects the PodMonitor and ServiceMonitor to be properly picked up by the Prometheus operator. It also consumes the newly-declared user metrics from worker pods.